### PR TITLE
Add fromUri PostgresqlDriver factory

### DIFF
--- a/lib/src/drivers/postgresql_driver.dart
+++ b/lib/src/drivers/postgresql_driver.dart
@@ -14,6 +14,19 @@ class PostgresqlDriver extends SqlDriver with SqlStandards {
       ? '?sslmode=require'
       : ''}';
 
+  factory PostgresqlDriver.fromUri(String uri) {
+    var connectionUri = Uri.parse(uri);
+    var userInfo = connectionUri.userInfo.split(':');
+
+    return new PostgresqlDriver(
+      host: connectionUri.host,
+      username: userInfo.first,
+      password: userInfo.last,
+      port: connectionUri.port,
+      database: connectionUri.pathSegments.first
+    );
+  }
+
   Future connect() async {
     _connection = await postgresql.connect(_uri);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trestle
 author: Emil Persson <emil.n.persson@gmail.com>
 homepage: https://github.com/dart-bridge/trestle
-version: 0.7.0
+version: 0.8.0
 environment:
   sdk: '>=1.12.0 <2.0.0'
 description: Database gateway and ORM


### PR DESCRIPTION
I keep my database connection information as an environment variable, postgres URI connection string.

This change lets me easily do this:

```dart
PostgresqlDriver driver = new PostgresqlDriver.fromUri(dotenv.env['DATABASE_URL']);
```